### PR TITLE
Add require auth middleware

### DIFF
--- a/internal/spotifyauth/auth.go
+++ b/internal/spotifyauth/auth.go
@@ -1,0 +1,1 @@
+package spotifyauth

--- a/internal/spotifyauth/middleware.go
+++ b/internal/spotifyauth/middleware.go
@@ -1,0 +1,39 @@
+package spotifyauth
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireAuth is a middleware that requires an access token for all routes except login and callback
+func RequireSpotifyAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract the Authorization header
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Authorization header missing"})
+			c.Abort()
+			return
+		}
+
+		// Ensure it's a Bearer token
+		tokenParts := strings.Split(authHeader, " ")
+		if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token format"})
+			c.Abort()
+			return
+		}
+
+		accessToken := tokenParts[1]
+
+		if accessToken == "" || !ValidateSpotifyToken(accessToken) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired Spotify token"})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/spotifyauth/token.go
+++ b/internal/spotifyauth/token.go
@@ -1,0 +1,22 @@
+package spotifyauth
+
+import (
+	"net/http"
+)
+
+// ValidateSpotifyToken checks if a token is valid by making a request to Spotify API
+func ValidateSpotifyToken(token string) bool {
+	req, _ := http.NewRequest("GET", "https://api.spotify.com/v1/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	// If Spotify API returns 200, the token is valid
+	println(resp.StatusCode)
+	return resp.StatusCode == http.StatusOK
+}


### PR DESCRIPTION
This pull request introduces a new package `spotifyauth` to handle Spotify authentication in a Go application. The changes include the creation of middleware for requiring Spotify authentication and a function to validate Spotify tokens.

### New package for Spotify authentication:

* [`internal/spotifyauth/auth.go`](diffhunk://#diff-c77a1cedb9bd9dc74245049829d83d5d972707381816c7e459ec1713a120f487R1): Created a new package `spotifyauth`.

### Middleware for requiring Spotify authentication:

* [`internal/spotifyauth/middleware.go`](diffhunk://#diff-d8b1f5983e404cf033c41b6b9c8cfceedd8f1ee713ba8214c41499c3100b1b5bR1-R39): Added `RequireSpotifyAuth` middleware to ensure routes are protected by requiring a valid Spotify access token.

### Token validation function:

* [`internal/spotifyauth/token.go`](diffhunk://#diff-92eb76b6563e0490e0da1f2568fe723ac25e6acb25f56dca91a77c880d340142R1-R22): Implemented `ValidateSpotifyToken` function to verify the validity of a Spotify access token by making a request to the Spotify API.