### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.24.4-bookworm
+
+WORKDIR /app
+COPY . .
+
+ENTRYPOINT ["go", "run", "cmd/music_share_api/main.go"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` for containerizing the application. The most important change is the addition of a base image, working directory, file copying, and an entry point to run the application.

Containerization setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R6): Added a new `Dockerfile` that uses the `golang:1.24.4-bookworm` image, sets the working directory to `/app`, copies all files into the container, and specifies the entry point to run `cmd/music_share_api/main.go`.